### PR TITLE
Fix support for Mac OS X.

### DIFF
--- a/se-leg/compose.yml
+++ b/se-leg/compose.yml
@@ -80,6 +80,8 @@ services:
     networks:
       dev:
         ipv4_address: 172.16.20.210
+    ports:
+      - "80:80"
     depends_on:
       - rp
       - op

--- a/start.sh
+++ b/start.sh
@@ -8,9 +8,7 @@ fi
 #
 # Set up entrys in /etc/hosts for the containers with externally accessible services
 #
-(printf "172.16.20.100\top\n";
- printf "172.16.20.200\trp\n";
- printf "172.16.20.210\tdemo.seleg_dev\n";
+( printf "127.0.0.1\tdemo.seleg_dev\n";
 ) \
     | while read line; do
     if ! grep -q "^${line}$" /etc/hosts; then


### PR DESCRIPTION
Expose the demo web server port so it can be accessed from the host
machine. The internal bridged network is not exposed on OS X, see e.g.
https://forums.docker.com/t/host-excluded-from-bridge-network/12015.
