### PR TITLE
[WIP] Update to work with new version of se-leg-op

### DIFF
--- a/mongodb/db-scripts/createUsers.sh
+++ b/mongodb/db-scripts/createUsers.sh
@@ -36,11 +36,7 @@ mongo localhost/se_leg_op --eval '
   db.clients.update({ "lookup_key" : "client1"},
                     { "lookup_key" : "client1",
                       "data" : {
-                          "response_types" : [[
-                              "code",
-                              "id_token",
-                              "token"
-                          ]],
+                          "response_types" : ["code id_token token"],
                           "redirect_uris" : [
                               "http://rp:5000/authorization-response"
                           ],


### PR DESCRIPTION
To work with the refactored se-leg-op (using the library pyop, see SUNET/se-leg-op#9), `response_types` needs to be a list of space separated strings.
